### PR TITLE
Add before and after insert hooks

### DIFF
--- a/eshell-fringe-status.el
+++ b/eshell-fringe-status.el
@@ -71,6 +71,16 @@ determines the look of the fringe indicator."
           (const :tag "Minus" efs-minus-bitmap)
           (const :tag "Plus" efs-plus-bitmap)))
 
+(defcustom eshell-fringe-status-before-insert-hook nil
+  "A list of functions to call before inserting the fringe status."
+  :group 'eshell-fringe-status
+  :type 'hook)
+
+(defcustom eshell-fringe-status-after-insert-hook nil
+  "A list of functions to call after inserting the fringe status."
+  :group 'eshell-fringe-status
+  :type 'hook)
+
 (defface eshell-fringe-status-success
   '((t (:foreground "#00aa00")))
   "Face used to indicate success status.
@@ -155,7 +165,9 @@ window."
     (save-excursion
       (beginning-of-line)
       (let ((inhibit-read-only t))
-        (insert (efs--propertized-text))))))
+        (run-hooks 'eshell-fringe-status-before-insert-hook)
+        (insert (efs--propertized-text))
+        (run-hooks 'eshell-fringe-status-after-insert-hook)))))
 
 ;;;###autoload
 (define-minor-mode eshell-fringe-status-mode


### PR DESCRIPTION
This PR adds hooks that are called before and after insertion of the fringe status.

I personally would like to use the before-insert-hook to be able to use the fringe status in combination with the [eshell-fixed-prompt](https://github.com/mallt/eshell-fixed-prompt-mode) package, but I guess other people might find other uses for them as well.

Thanks!